### PR TITLE
Show song data

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,127 +1,17 @@
 require('dotenv').config()
 
-const clientId = process.env.SPOTIFY_CLIENT_ID
-const clientSecret = process.env.SPOTIFY_SECRET
 const cookieParser = require('cookie-parser')
-const cors = require('cors')
-const express = require('express')
-let LocalStorage = require('node-localstorage').LocalStorage
-localStorage = new LocalStorage('./localStorage')
-const passport = require('passport')
-const search = require('./app/helpers/search')
-var session = require('express-session')
-const SpotifyStrategy = require('./lib/passport-spotify/index').Strategy
-const trackAnalysis = require('./app/helpers/audioAnalysis')
-const request = require('request')
+const routes = require('./routes')
 
-const CALLBACK_URL = 'https://spotify-viz-api.herokuapp.com/callback/'
-const FRONTEND_URL = 'https://spotify-viz-frontend.herokuapp.com'
-// const CALLBACK_URL = 'http://localhost:3001/callback'
-// const FRONTEND_URL = 'http://localhost:3000'
+const app = require('express')()
 
-const corsOptions = {
-  origin: FRONTEND_URL,
-  credentials: true
-}
-
-passport.serializeUser((user, done) => {
-  done(null, user)
-})
-
-passport.deserializeUser((obj, done) => {
-  done(null, obj)
-})
-
-const app = express()
-app.use(express.static(__dirname + '/public'))
-  .use(cookieParser('keyboard_cat'))
-
-app.use(session({
-  key: 'user_sid',
-  secret: 'keyboard_cat',
-  resave: false,
-  saveUninitialized: true,
-  cookie: { expires: 60000 * 60 * 24, secure: false, httpOnly: false }
-
-}))
-
-app.use(passport.initialize())
-app.use(passport.session())
+app.use('/', routes)
+app.use(cookieParser('keyboard_cat'))
 app.set('trust proxy', 1)
-
-passport.use(new SpotifyStrategy({
-  clientID: clientId,
-  clientSecret: clientSecret,
-  callbackURL: CALLBACK_URL
-},
-  (accessToken, refreshToken, profile, done) => {
-    process.nextTick(() => {
-      let user = { spotifyId: profile.id, access_token: accessToken, refresh_token: refreshToken }
-      return done(null, user)
-    })
-  }))
-
-app.get('/auth/spotify',
-  passport.authenticate('spotify', {scope: ['user-read-email', 'user-read-private'], showDialog: true}),
-  (req, res) => {
-  })
-
-app.get('/callback', passport.authenticate('spotify', { failureRedirect: '/' }), (req, res) => {
-  localStorage.setItem('access_token_' + req.session.id, req.user.access_token)
-  localStorage.setItem('refresh_token_' + req.session.id, req.user.refresh_token)
-  res.redirect(FRONTEND_URL)
-})
-
-app.get('/', cors(corsOptions), (req, res) => {
-  if (req.isAuthenticated()) {
-    res.json({isAuthenticated: true })
-  } else {
-    res.json({isAuthenticated: false})
-  }
-})
-
-app.get('/refreshToken', (req, res) => {
-  var refresh_token = localStorage.getItem('refresh_token')
-
-  var authOptions = {
-    url: 'https://accounts.spotify.com/api/token',
-    headers: {
-      'Authorization': 'Basic ' + (new Buffer(clientId + ':' + clientSecret).toString('base64'))
-    },
-    form: {
-      grant_type: 'refresh_token',
-      refresh_token: refresh_token
-    },
-    json: true
-  }
-
-  request.post(authOptions, (error, response, body) => {
-    if (!error && response.statusCode === 200) {
-      var accessToken = body.access_token
-      localStorage.setItem('access_token', accessToken)
-      res.send({
-        'access_token': accessToken
-      })
-    }
-  })
-})
-
-app.get('/logout', (req, res) => {
-  req.session.destroy()
-  res.redirect('/')
-})
-
-app.get('/search', cors(corsOptions), (req, res) => {
-  search.searchTracks(req, res)
-})
-
-app.get('/analyze/:id', cors(corsOptions), (req, res) => {
-  const id = req.params.id
-  trackAnalysis.analyzeTrack(req, res, id)
-})
 
 const dbUsername = process.env.SPOTIFY_DB_USERNAME
 const dbPassword = process.env.SPOTIFY_DB_PASSWORD
+
 const MongoClient = require('mongodb').MongoClient
 const port = process.env.PORT || 3001
 

--- a/app/helpers/audioAnalysis.js
+++ b/app/helpers/audioAnalysis.js
@@ -1,20 +1,32 @@
-const request = require('request')
+var request = require('request-promise')
+var Promise = require('bluebird')
 
 module.exports = {
   analyzeTrack: function (req, res, id) {
     const accessToken = localStorage.getItem('access_token_' + req.session.id)
-    const options = {
+    var requests = [{
       url: 'https://api.spotify.com/v1/audio-features/' + id,
       headers: { 'Authorization': 'Bearer ' + accessToken },
       json: true
-    }
+    }, {
+      url: 'https://api.spotify.com/v1/tracks/' + id,
+      headers: { 'Authorization': 'Bearer ' + accessToken },
+      json: true
+    },
+    {
+      url: 'https://api.spotify.com/v1/audio-analysis/' + id,
+      headers: { 'Authorization': 'Bearer ' + accessToken },
+      json: true
+    }]
 
-    request.get(options, (error, response, body) => {
-      if (error) {
-        res.render(error)
-      } else {
-        res.send(body)
-      }
+    Promise.map(requests, (obj) => {
+      return request(obj).then((body) => {
+        return body
+      })
+    }).then((results) => {
+      res.send(results)
+    }, {concurrency: 3}, (err) => {
+      console.log(err)
     })
   }
 }

--- a/app/helpers/search.js
+++ b/app/helpers/search.js
@@ -1,7 +1,5 @@
 const request = require('request')
 
-// TODO: use bodyParser instead of JSON.parse
-
 module.exports = {
   searchTracks: (req, res, sessionId) => {
     const accessToken = localStorage.getItem('access_token_' + req.session.id)

--- a/package.json
+++ b/package.json
@@ -5,11 +5,13 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha",
+    "dev": "nodemon app.js",
     "start": "node app.js"
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "bluebird": "^3.5.1",
     "cookie-parser": "^1.4.3",
     "cors": "^2.8.4",
     "dotenv": "^4.0.0",
@@ -19,6 +21,7 @@
     "ms": "^2.0.0",
     "node-localstorage": "^1.3.0",
     "node-pre-gyp": "^0.6.36",
+    "nodemon": "^1.12.1",
     "nopt": "^4.0.1",
     "passport": "^0.4.0",
     "passport-oauth": "^1.0.0",
@@ -27,6 +30,7 @@
     "qs": "^6.5.0",
     "readable-stream": "^2.3.3",
     "request": "^2.81.0",
+    "request-promise": "^4.2.2",
     "string_decoder": "^1.0.3"
   },
   "devDependencies": {

--- a/routes.js
+++ b/routes.js
@@ -1,0 +1,117 @@
+const cors = require('cors')
+const passport = require('passport')
+const clientId = process.env.SPOTIFY_CLIENT_ID
+const clientSecret = process.env.SPOTIFY_SECRET
+var session = require('express-session')
+let LocalStorage = require('node-localstorage').LocalStorage
+localStorage = new LocalStorage('./localStorage')
+const search = require('./app/helpers/search')
+const trackAnalysis = require('./app/helpers/audioAnalysis')
+const request = require('request')
+
+const routes = require('express').Router()
+
+// const CALLBACK_URL = 'http://localhost:3001/callback'
+// const FRONTEND_URL = 'http://localhost:3000'
+const CALLBACK_URL = 'https://spotify-viz-api.herokuapp.com/callback/'
+const FRONTEND_URL = 'https://spotify-viz-frontend.herokuapp.com'
+
+const SpotifyStrategy = require('./lib/passport-spotify/index').Strategy
+
+const corsOptions = {
+  origin: FRONTEND_URL,
+  credentials: true
+}
+
+passport.serializeUser((user, done) => {
+  done(null, user)
+})
+
+passport.deserializeUser((obj, done) => {
+  done(null, obj)
+})
+
+routes.use(session({
+  key: 'user_sid',
+  secret: 'keyboard_cat',
+  resave: false,
+  saveUninitialized: true,
+  cookie: { expires: 60000 * 60 * 24, secure: false, httpOnly: false }
+
+}))
+
+routes.use(passport.initialize())
+routes.use(passport.session())
+
+passport.use(new SpotifyStrategy({
+  clientID: clientId,
+  clientSecret: clientSecret,
+  callbackURL: CALLBACK_URL
+},
+  (accessToken, refreshToken, profile, done) => {
+    process.nextTick(() => {
+      let user = { spotifyId: profile.id, access_token: accessToken, refresh_token: refreshToken }
+      return done(null, user)
+    })
+  }))
+
+routes.get('/auth/spotify',
+  passport.authenticate('spotify', {scope: ['user-read-email', 'user-read-private'], showDialog: true}),
+  (req, res) => {
+  })
+
+routes.get('/callback', passport.authenticate('spotify', { failureRedirect: '/' }), (req, res) => {
+  localStorage.setItem('access_token_' + req.session.id, req.user.access_token)
+  localStorage.setItem('refresh_token_' + req.session.id, req.user.refresh_token)
+  res.redirect(FRONTEND_URL)
+})
+
+routes.get('/refreshToken', (req, res) => {
+  var refresh_token = localStorage.getItem('refresh_token')
+
+  var authOptions = {
+    url: 'https://accounts.spotify.com/api/token',
+    headers: {
+      'Authorization': 'Basic ' + (Buffer.from(clientId + ':' + clientSecret).toString('base64'))
+    },
+    form: {
+      grant_type: 'refresh_token',
+      refresh_token: refresh_token
+    },
+    json: true
+  }
+
+  request.post(authOptions, (error, response, body) => {
+    if (!error && response.statusCode === 200) {
+      var accessToken = body.access_token
+      localStorage.setItem('access_token', accessToken)
+      res.send({
+        'access_token': accessToken
+      })
+    }
+  })
+})
+
+routes.get('/', cors(corsOptions), (req, res) => {
+  if (req.isAuthenticated()) {
+    res.json({ isAuthenticated: true })
+  } else {
+    res.status(200).json({ isAuthenticated: false })
+  }
+})
+
+routes.get('/search', cors(corsOptions), (req, res) => {
+  search.searchTracks(req, res)
+})
+
+routes.get('/analyze/:id', cors(corsOptions), (req, res) => {
+  const id = req.params.id
+  trackAnalysis.analyzeTrack(req, res, id)
+})
+
+routes.get('/logout', (req, res) => {
+  req.session.destroy()
+  res.redirect('/')
+})
+
+module.exports = routes


### PR DESCRIPTION
**Refactor routes, get audio analysis from Spotify API**
* Run nodemon in development instead of node
* Pull routes out of app.js and into routes.js to make it a bit more organized * Update /analyze/:id endpoint to also pull track data
* Get audio analysis from Spotify API
* Add concurrency